### PR TITLE
Disable MutableConstant cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,5 +53,8 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
-Performance/ParallelAssignment:
+Style/ParallelAssignment:
+  Enabled: false
+
+Style/MutableConstant:
   Enabled: false


### PR DESCRIPTION
Prevents complaints about string values assigned to constants not being frozen. Also update the name of a cop in line with changes upstream.