### PR TITLE
Disable Rails/FilePath and Rails/Delegate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,12 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/Delegate:
+  Enabled: false
+
+Rails/FilePath:
+  Enabled: false
+
 Documentation:
   Enabled: false
 
@@ -23,7 +29,7 @@ Layout/EmptyLinesAroundClassBody:
 Layout/IndentHash:
   Enabled: true
   EnforcedLastArgumentHashStyle: ignore_implicit
-  
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
 


### PR DESCRIPTION
- FilePath: we don't use Windows, so no reason to worry about different path separators
- Delegate: I think this often feels like implicit behaviour, unless the object's *role* is somehow to delegate methods elsewhere