### PR TITLE
Remove old Layout/IndentHash cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,10 +45,6 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
-Layout/IndentHash:
-  Enabled: true
-  EnforcedLastArgumentHashStyle: ignore_implicit
-
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
 


### PR DESCRIPTION
This setting is now removed and causes errors in the latest rubocop