### PR TITLE
Update target ruby and rails versions, add rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
+require: rubocop-rspec
+
 AllCops:
-  TargetRubyVersion: 2.3
-  TargetRailsVersion: 4
+  TargetRubyVersion: 2.5
+  TargetRailsVersion: 5.2
 
   Exclude:
     - tmp/**/*


### PR DESCRIPTION
This would mean you'd need to `gem install rubocop-rspec` on your host machine, so I'm happy to remove rubocop-rspec if people object. The reason I added it is that it gives you nice autocorrection over changes to FactoryBot (the most recent version forces you to use blocks to set attributes in factories).