### PR TITLE
Update .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - db/**/*
     - Guardfile
     - lib/tasks/cucumber.rake
+    - project_secrets.rb
 
 Bundler/OrderedGems:
   Enabled: false


### PR DESCRIPTION
As e.g. removing trailing commas means hashes don't match.