### PR TITLE
Disable Rails/InverseOf

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,9 @@ Rails/Blank:
 Rails/Delegate:
   Enabled: false
 
+Rails/InverseOf:
+  Enabled: false
+
 Rails/FilePath:
   Enabled: false
 


### PR DESCRIPTION
We mostly don't need or use `inverse_of`.