### PR TITLE
Update RSpec/FilePath cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -177,3 +177,9 @@ RSpec/ExampleLength:
 
 RSpec/FilePath:
   Enabled: false
+
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/SpecFilePathSuffix:
+  Enabled: true


### PR DESCRIPTION
Fixing:
```
Error: The `RSpec/FilePath` cop has been split into `RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-geome-geo-me-rubocop-master--rubocop-yml, please update it)
```