### PR TITLE
Update config for rubocop 1.72+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
   - rubocop-rails
   - rubocop-performance


### PR DESCRIPTION
https://github.com/rubocop/rubocop-rails#rubocop-configuration-file

> The plugin system is supported in RuboCop 1.72+. In earlier versions, use require instead of plugins.