### PR TITLE
Update rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -172,9 +172,6 @@ RSpec/NestedGroups:
 RSpec/ExampleLength:
   Max: 8
 
-RSpec/FilePath:
-  Enabled: false
-
 RSpec/SpecFilePathFormat:
   Enabled: false
 


### PR DESCRIPTION
Prevent:
```
Error: The `RSpec/FilePath` cop has been split into `RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-geome-geo-me-rubocop-master--rubocop-yml, please update it)
```